### PR TITLE
🐛 Update bootstrap-grid.scss

### DIFF
--- a/bootstrap-grid/scss/pico-bootstrap-grid.scss
+++ b/bootstrap-grid/scss/pico-bootstrap-grid.scss
@@ -22,4 +22,5 @@ $grid-breakpoints: (
 @import "bootstrap/scss/mixins/grid";
 @import "bootstrap/scss/mixins/utilities";
 @import "bootstrap/scss/vendor/rfs";
+@import "bootstrap/scss/containers";
 @import "bootstrap/scss/grid";


### PR DESCRIPTION
### Problem: The container class does not have `max-width` property with `bootstrap-grid.scss`

Container class as of this moment only has the following properties.

```css
.container, .container-fluid {
  width: 100%;
  margin-right: auto;
  margin-left: auto;
  padding-right: var(--spacing);
  padding-left: var(--spacing);
}
```
It does not have `max-witdth` or support for responsiveness.
![image](https://user-images.githubusercontent.com/37541747/224447608-d81f2cde-78d2-4906-b155-b59378effba6.png)
The classes .container-sm, .container-md, etc do not work.

### Solution: Adding the `_container.scss` file that sets the containers max width

This piece of code, which sets the `max-width` property for the `.container` class
```css
.container-xl, .container-lg, .container-md, .container-sm, .container {
  max-width: 1320px;
}
```

And in sass, the property is generated by this file
- sass path `@import "bootstrap/scss/containers";`
- file path `node_modules/bootstrap/scss/_containers.scss`
```scss
@if $enable-container-classes {
  // Single container class with breakpoint max-widths
  .container,
  // 100% wide container at all breakpoints
  .container-fluid {
    @include make-container();
  }

  // Responsive containers that are 100% wide until a breakpoint
  @each $breakpoint, $container-max-width in $container-max-widths {
    .container-#{$breakpoint} {
      @extend .container-fluid;
    }

    @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
      %responsive-container-#{$breakpoint} {
        max-width: $container-max-width; // <================
      }

      // Extend each breakpoint which is smaller or equal to the current breakpoint
      $extend-breakpoint: true;

      @each $name, $width in $grid-breakpoints {
        @if ($extend-breakpoint) {
          .container#{breakpoint-infix($name, $grid-breakpoints)} {
            @extend %responsive-container-#{$breakpoint};
          }

          // Once the current breakpoint is reached, stop extending
          @if ($breakpoint == $name) {
            $extend-breakpoint: false;
          }
        }
      }
    }
  }
}
```
Thus, the `"bootstrap/scss/containers"` file is needed to set the max-width property.
```scss
... // extra files
@import "bootstrap/scss/mixins/container";
@import "bootstrap/scss/mixins/grid";
@import "bootstrap/scss/mixins/utilities";
@import "bootstrap/scss/vendor/rfs";
@import "bootstrap/scss/containers"; // <- added here   ໒(⊙ᴗ⊙)७✎▤
@import "bootstrap/scss/grid";
```